### PR TITLE
Move mail settings from KW to common repository

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,11 @@
+from .mail.env import ENV_SCHEMA as MAIL_ENV_SCHEMA
+
+# kwargs to be added to arguments to django-environ's Env.__init__()
+ENV_SCHEMA = dict(
+    **MAIL_ENV_SCHEMA,
+)
+
+
+def register_settings(settings: dict):
+    from .mail.settings import register_settings as register_mail_settings
+    register_mail_settings(settings)

--- a/mail/env.py
+++ b/mail/env.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+# kwargs to be added to arguments to django-environ's Env.__init__()
+ENV_SCHEMA = dict(
+    ALLOWED_SENDER_EMAILS=(list, []),
+    SERVER_EMAIL=(str, ''),
+    DEFAULT_FROM_EMAIL=(str, 'noreply@mj.kausal.tech'),
+    DEFAULT_FROM_NAME=(str, 'Kausal'),
+    MAILGUN_API_KEY=(str, ''),
+    MAILGUN_SENDER_DOMAIN=(str, ''),
+    MAILGUN_REGION=(str, ''),
+    MAILJET_API_KEY=(str, ''),
+    MAILJET_SECRET_KEY=(str, ''),
+    SENDGRID_API_KEY=(str, ''),
+)

--- a/mail/settings.py
+++ b/mail/settings.py
@@ -1,0 +1,44 @@
+# ruff: noqa: N806
+from __future__ import annotations
+
+
+def register_settings(settings: dict):
+    # All local variables here (except `settings` itself) will be put in `settings`
+    # Pull some out for convenience
+    env = settings['env']
+    DEBUG = settings['DEBUG']
+
+    settings['INSTALLED_APPS'].append('anymail')
+
+    ALLOWED_SENDER_EMAILS = env('ALLOWED_SENDER_EMAILS')
+    SERVER_EMAIL = env('SERVER_EMAIL')
+    if not SERVER_EMAIL and ALLOWED_SENDER_EMAILS:
+        SERVER_EMAIL = ALLOWED_SENDER_EMAILS[0]
+    DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL')
+    if not DEFAULT_FROM_EMAIL and ALLOWED_SENDER_EMAILS:
+        DEFAULT_FROM_EMAIL = ALLOWED_SENDER_EMAILS[0]
+    DEFAULT_FROM_NAME = env('DEFAULT_FROM_NAME')
+
+    EMAIL_BACKEND = 'anymail.backends.console.EmailBackend'
+    ANYMAIL = {}
+
+    if env.str('MAILGUN_API_KEY'):
+        EMAIL_BACKEND = 'anymail.backends.mailgun.EmailBackend'
+        ANYMAIL['MAILGUN_API_KEY'] = env.str('MAILGUN_API_KEY')
+        ANYMAIL['MAILGUN_SENDER_DOMAIN'] = env.str('MAILGUN_SENDER_DOMAIN')
+        if env.str('MAILGUN_REGION'):
+            ANYMAIL['MAILGUN_API_URL'] = 'https://api.%s.mailgun.net/v3' % env.str('MAILGUN_REGION')
+
+    if env.str('SENDGRID_API_KEY'):
+        EMAIL_BACKEND = 'anymail.backends.sendgrid.EmailBackend'
+        ANYMAIL['SENDGRID_API_KEY'] = env.str('SENDGRID_API_KEY')
+
+    if env.str('MAILJET_API_KEY'):
+        EMAIL_BACKEND = 'anymail.backends.mailjet.EmailBackend'
+        ANYMAIL['MAILJET_API_KEY'] = env.str('MAILJET_API_KEY')
+        ANYMAIL['MAILJET_SECRET_KEY'] = env.str('MAILJET_SECRET_KEY')
+
+    if DEBUG:
+        EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+    settings.update({key: value for key, value in locals().items() if key != 'settings'})


### PR DESCRIPTION
# Background

Kausal Watch configures some email settings. Kausal Paths doesn't do so, but we now want to be able to send emails also from Paths. This PR pulls the email configuration from Watch and puts it into `kausal-backend-common`, so it can then also be used from Paths.

# How to migrate to this

This describes the changes you'd have to do to the Kausal Watch backend to take this PR into use.

Put the following in `settings.py`:
```
from kausal_common import ENV_SCHEMA as COMMON_ENV_SCHEMA, register_settings as register_common_settings
```

Remove the following email-related variables from the arguments to `environ.FileAwareEnv()`:
- `ALLOWED_SENDER_EMAILS`
- `DEFAULT_FROM_EMAIL`
- `DEFAULT_FROM_NAME`
- `MAILGUN_API_KEY`
- `MAILGUN_REGION`
- `MAILGUN_SENDER_DOMAIN`
- `MAILJET_API_KEY`
- `MAILJET_SECRET_KEY`
- `SENDGRID_API_KEY`
- `SERVER_EMAIL`

Instead, your `env` definition should look like this:
```
env = environ.FileAwareEnv(
    # [old content minus email-related variables]
    **COMMON_ENV_SCHEMA,
)
```

Remove the following email-related settings:
- `ALLOWED_SENDER_EMAILS`
- `ANYMAIL`
- `DEFAULT_FROM_EMAIL`
- `DEFAULT_FROM_NAME`
- `EMAIL_BACKEND`
- `SERVER_EMAIL`

Instead, add this:
```
register_common_settings(locals())
```

Remove `anymail` from `INSTALLED_APPS`. The function `register_common_settings` will register `anymail`.

# Caveats

The `django-anymail` requirement from Kausal Watch should ideally be moved to `requirements-common.txt`. However, this seems difficult at the moment because projects using `kausal-backend-common` may use different versions of Django or other packages on which `django-anymail` depends. For the time being, each project must declare these requirements separately.

# How to incorporate this into Paths or other projects

The additions to `settings.py` are the same as described above for Watch. Don't forget to add the `anymail` requirements to Paths (see "Caveats" above).