### PR TITLE
[DSBUG-22] Add mixin for hiding snippets from view breadcrumbs

### DIFF
--- a/admin_site/mixins.py
+++ b/admin_site/mixins.py
@@ -1,0 +1,11 @@
+"""Mixins for Wagtail admin UI views."""
+from __future__ import annotations
+
+
+class HideSnippetsFromBreadcrumbsMixin:
+    """Hide access to snippets index view from view breadcrumbs."""
+
+    def get_breadcrumbs_items(self) -> list[dict]:
+        breadcrumb_items = super().get_breadcrumbs_items()  # type: ignore
+        breadcrumb_items = [item for item in breadcrumb_items if item['label'] != 'Snippets']
+        return breadcrumb_items


### PR DESCRIPTION
When this mixin has been applied, the `Snippets` item has been removed from view breadcrumbs, e.g. here it now shows `Home -> Datasets` instead of `Home -> Snippets -> Datasets`:

![hidden_snippets](https://github.com/user-attachments/assets/b51586d4-cf54-444b-90f7-5d4808198b91)
