### PR TITLE
Authenticate user emails case insensitively

### DIFF
--- a/auth/pipeline.py
+++ b/auth/pipeline.py
@@ -83,7 +83,7 @@ def find_user_by_email(backend, details, user=None, social=None, *args, **kwargs
 
     details['email'] = details['email'].lower()
     try:
-        user = User.objects.get(email=details['email'])
+        user = User.objects.get(email__iexact=details['email'])
     except User.DoesNotExist:
         return None
 


### PR DESCRIPTION
To make things easier with people using/not using capitalized names in their emails, use case insensitive search when finding users by email.