### PR TITLE
Bugfix: avoid null value generated by modeltrans crashing db

### DIFF
--- a/organizations/models.py
+++ b/organizations/models.py
@@ -136,6 +136,7 @@ class BaseOrganization(index.Indexed, ModelWithPrimaryLanguage, gis_models.Model
     abbreviation = models.CharField(
         max_length=50,
         blank=True,
+        null=True,
         verbose_name=_('Short name'),
         help_text=_('A simplified short version of name for the general public'),
     )


### PR DESCRIPTION
django-modeltrans translated fields do not support NOT NULL restrictions properly in some cases. Before investigating further, let's merge this fix because currently the Organization form cannot be saved with an empty "Short name"