### PR TITLE
Add primary language field to organization public fields

### DIFF
--- a/organizations/models.py
+++ b/organizations/models.py
@@ -188,7 +188,7 @@ class BaseOrganization(index.Indexed, TreeModel, ModelWithPrimaryLanguage, gis_m
 
     i18n = TranslationField(fields=('name', 'abbreviation'), default_language_field='primary_language_lowercase')
 
-    public_fields: ClassVar[list[str]] = ['id', 'uuid', 'name', 'abbreviation', 'parent']
+    public_fields: ClassVar[list[str]] = ['id', 'uuid', 'name', 'abbreviation', 'parent', 'primary_language']
 
     search_fields = [
         index.AutocompleteField('name'),


### PR DESCRIPTION
Allows it to be explicitly set via REST API if needed, and also implicitly according to the current plan/instanceconfig.


### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs)

Please merge at the same time as Watch & Paths PRs
https://github.com/kausaltech/kausal-watch/pull/547
https://github.com/kausaltech/kausal-paths/pull/251