### PR TITLE
Skip Sentry capture for GraphQL client-side errors

### DIFF
--- a/strawberry/schema.py
+++ b/strawberry/schema.py
@@ -73,9 +73,11 @@ class Schema(ABC, GrapheneStrawberrySchema):
         errors_printed = 0
         for error in errors:
             path_str = '.'.join(str(part) for part in error.path) if error.path else 'unknown'
-            if not isinstance(error.original_error, (GraphQLError, PermissionDenied)):
-                logger.opt(exception=error.original_error).bind(graphql_path=path_str).error(error)
-                errors_printed += 1
+            if isinstance(error.original_error, (GraphQLError, PermissionDenied)):
+                logger.bind(graphql_path=path_str).warning('Client-side GraphQL error: {}', error.message)
+                continue
+            logger.opt(exception=error.original_error).bind(graphql_path=path_str).error(error)
+            errors_printed += 1
             if error.original_error and errors_sent < 5:
                 sentry_sdk.capture_exception(error.original_error)
                 errors_sent += 1


### PR DESCRIPTION
## Description
GraphQLError and PermissionDenied are client-side errors that belong in the GraphQL response errors array, not in Sentry. These include validation failures, permission checks, and user input errors.

Move sentry_sdk.capture_exception() inside the non-client-error branch so only unexpected server errors get reported to Sentry. Client-side errors are still logged via loguru at warning level for visibility in Grafana/Loki.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally in all affected projects** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs)
