### PR TITLE
Handle false value for DB_RESTORE_FROM_BACKUP as expected

### DIFF
--- a/docker/run-migrations.sh
+++ b/docker/run-migrations.sh
@@ -7,9 +7,9 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 
 function restore_from_backup() {
-    if [ -z "$DB_RESTORE_FROM_BACKUP" ] ; then
-        return
-    fi
+    case "${DB_RESTORE_FROM_BACKUP:-}" in
+        ''|0|false|no) return ;;
+    esac
     # Check we already have tables in the database
     tmpf=$(mktemp)
     echo "select count(*) from information_schema.tables where table_schema = 'public';" | ./manage.py dbshell -- -qtAX -o $tmpf


### PR DESCRIPTION
Previously, if DB_RESTORE_FROM_BACKUP was set to 0, false or no, it would be considered truthy. These values are now treated as expected.