### PR TITLE
storage: route ci deployments to S3 fallback

### DIFF
--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -26,7 +26,7 @@ def storage_settings_from_s3_url(url: ParseResult, deployment_type: str | None =
     for key, val in parse_qs(url.query).items():
         assert len(val) == 1
         opts[key] = val[0]
-    if deployment_type == 'development':
+    if deployment_type in ('development', 'ci'):
         backend = 'kausal_common.storage.storage_classes.LocalMediaStorageWithS3Fallback'
     else:
         backend = 'kausal_common.storage.storage_classes.MediaFilesS3Storage'


### PR DESCRIPTION
## Description
Use LocalMediaStorageWithS3Fallback when `DEPLOYMENT_TYPE` is `'ci'`, so the bundled SQL dump's media references
resolve against the configured bucket instead of failing on an empty local FS (WATCH-BACKEND-3NR).
No-op until the ci environment sets `S3_MEDIA_STORAGE_URL`

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x]  Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally in all affected projects** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs)
