### PR TITLE
Fix bulk update validation instance matching

### DIFF
--- a/api/bulk.py
+++ b/api/bulk.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import typing
 from typing import Any
 
-from django.db import models
 from django.db.models.base import Model
 from django.db.models.query import QuerySet
 from rest_framework import response, serializers, status, viewsets
@@ -30,9 +29,9 @@ class BulkSerializerValidationInstanceMixin[M: Model](ModelSerializerMixinBase[M
     _instance: M | None
 
     def run_validation(self, data: Any = serializers.empty) -> Any:
-        if self.parent and self.instance is not None:
-            assert isinstance(self.instance, models.query.QuerySet)
-            self._instance = self.parent.objs_by_id.get(data['id'])
+        if self.parent and self.parent.instance is not None:
+            obj_id = data.get(self.parent.update_lookup_field)
+            self._instance = self.parent.objs_by_id.get(obj_id)
         else:
             self._instance = self.instance
         return super().run_validation(data)
@@ -103,6 +102,16 @@ class BulkListSerializer[M: Model](serializers.ListSerializer[QuerySet[M]]):
             raise ValidationError(errors)
 
         return super().to_internal_value(data)
+
+    def run_child_validation(self, data: Any) -> Any:
+        old_instance = self.child.instance
+        if self.instance is not None:
+            obj_id = data.get(self.update_lookup_field)
+            self.child.instance = self.objs_by_id.get(obj_id)
+        try:
+            return super().run_child_validation(data)
+        finally:
+            self.child.instance = old_instance
 
     def _handle_updates(self, update_ops: Mapping[type[M], Sequence[tuple[M, Sequence[str]]]]) -> None:
         for model, ops in update_ops.items():

--- a/datasets/tests/test_api.py
+++ b/datasets/tests/test_api.py
@@ -48,8 +48,14 @@ def serializer_context(dataset, api_factory):
     return {'view': type('obj', (object,), {'kwargs': {'dataset_uuid': str(dataset.uuid)}}), 'request': request}
 
 
-def test_data_point_bulk_serializer_save_without_changes_keeps_data(serializer_context):
+def get_serializer_context(dataset, api_factory):
+    request = api_factory.put(f'/datasets/{dataset.uuid}/data_points/')
+    return {'view': type('obj', (object,), {'kwargs': {'dataset_uuid': str(dataset.uuid)}}), 'request': request}
+
+
+def test_data_point_bulk_serializer_save_without_changes_keeps_data(api_factory):
     ds = DatasetFactory.create()
+    serializer_context = get_serializer_context(ds, api_factory)
     data_points = [DataPointFactory.create(dataset=ds) for _ in range(2)]
     serialized_data_points = [
         DataPointSerializer(instance=data_point, context=serializer_context).data for data_point in data_points
@@ -65,8 +71,9 @@ def test_data_point_bulk_serializer_save_without_changes_keeps_data(serializer_c
     assert serialized_data_points_after_save == serialized_data_points
 
 
-def test_data_point_bulk_serializer_save_with_changes_updates_data(serializer_context):
+def test_data_point_bulk_serializer_save_with_changes_updates_data(api_factory):
     ds = DatasetFactory.create()
+    serializer_context = get_serializer_context(ds, api_factory)
     data_points = [DataPointFactory.create(dataset=ds) for _ in range(2)]
     serialized_data_points = [
         DataPointSerializer(instance=data_point, context=serializer_context).data for data_point in data_points


### PR DESCRIPTION
Bulk update validation matched payload UUIDs to queryset objects only in the list serializer, so child serializers still validated without their existing instance. Data point duplicate validation then treated an unchanged PUT row like a create and found the row itself as a duplicate. Pass the matched object into child validation and keep the bulk validation helper using the list serializer lookup so update validators can exclude the current instance.

## Related issue
[Slack thread](https://kausaltech.slack.com/archives/C0220JEEV1C/p1780576175907849)

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [x] **Manually tested locally in all affected projects** (functionality verified)