### PR TITLE
Don't let S3 media uploads overwrite an existing object

### DIFF
--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -1,20 +1,40 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs
 
 if TYPE_CHECKING:
     from urllib.parse import ParseResult
 
+_BOOLEAN_OPTION_VALUES = {
+    'true': True,
+    'yes': True,
+    'on': True,
+    'false': False,
+    'no': False,
+    'off': False,
+}
 
-def storage_settings_from_s3_url(url: ParseResult, deployment_type: str | None = None):
+
+def _parse_option_value(value: str) -> str | bool:
+    """
+    Convert an option value that spells out a boolean.
+
+    Everything in a query string arrives as a string, and a non-empty string is truthy: without
+    this, `?file_overwrite=false` would switch overwriting on rather than off. Numeric values are
+    left alone so that options which take a number aren't turned into booleans.
+    """
+    return _BOOLEAN_OPTION_VALUES.get(value.lower(), value)
+
+
+def storage_settings_from_s3_url(url: ParseResult, deployment_type: str | None = None) -> dict[str, Any]:
     assert url.scheme == 's3'
     if deployment_type is None:
         from django.conf import settings
 
         deployment_type = settings.DEPLOYMENT_TYPE
 
-    opts = {
+    opts: dict[str, Any] = {
         'bucket_name': url.path.lstrip('/'),
     }
     if url.hostname:
@@ -25,7 +45,7 @@ def storage_settings_from_s3_url(url: ParseResult, deployment_type: str | None =
         opts['secret_key'] = url.password
     for key, val in parse_qs(url.query).items():
         assert len(val) == 1
-        opts[key] = val[0]
+        opts[key] = _parse_option_value(val[0])
     if deployment_type in ('development', 'ci'):
         backend = 'kausal_common.storage.storage_classes.LocalMediaStorageWithS3Fallback'
     else:

--- a/storage/storage_classes.py
+++ b/storage/storage_classes.py
@@ -21,6 +21,12 @@ class MediaFilesS3Storage(S3Boto3Storage):
 
     def get_default_settings(self):
         defaults = super().get_default_settings()
+        # django-storages defaults `file_overwrite` to True, which turns off the filename
+        # de-duplication that Django and Wagtail rely on: `get_available_name` then hands back the
+        # requested key even when it is taken, so two uploads of the same filename end up sharing a
+        # single object and deleting either one destroys the other's file. Note that a plain class
+        # attribute would not do: `BaseStorage.__init__` applies these defaults over the instance.
+        defaults['file_overwrite'] = False
         # Rename some settings to avoid conflicts with other S3 backends
         defaults['access_key'] = setting('MEDIA_FILES_S3_ACCESS_KEY')
         defaults['secret_key'] = setting('MEDIA_FILES_S3_SECRET_ACCESS_KEY')

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+import pytest
+
+from kausal_common.storage import storage_settings_from_s3_url
+from kausal_common.storage.storage_classes import MediaFilesS3Storage
+
+
+def test_media_storage_does_not_overwrite_existing_files():
+    """
+    Uploads must not be allowed to land on a key that is already taken.
+
+    With `file_overwrite` on, `get_available_name` returns the requested key even when another
+    object uses it, so two objects end up sharing one file and deleting either destroys the other.
+    """
+    storage = MediaFilesS3Storage(bucket_name='test-bucket')
+
+    assert storage.file_overwrite is False  # pyright: ignore[reportAttributeAccessIssue]
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [('false', False), ('False', False), ('no', False), ('off', False), ('true', True), ('yes', True)],
+)
+def test_boolean_options_are_parsed_from_the_query_string(value, expected):
+    """Non-empty strings are truthy, so `?file_overwrite=false` must not switch overwriting on."""
+    url = urlparse(f's3://key:secret@s3.example.com/bucket?file_overwrite={value}')
+
+    settings = storage_settings_from_s3_url(url, deployment_type='production')
+
+    assert settings['OPTIONS']['file_overwrite'] is expected
+
+
+def test_non_boolean_options_are_left_as_strings():
+    url = urlparse('s3://key:secret@s3.example.com/bucket?addressing_style=virtual')
+
+    settings = storage_settings_from_s3_url(url, deployment_type='production')
+
+    assert settings['OPTIONS']['addressing_style'] == 'virtual'
+    assert settings['OPTIONS']['bucket_name'] == 'bucket'


### PR DESCRIPTION
django-storages defaults `file_overwrite` to True, which turns off the filename de-duplication that Django and Wagtail rely on: `get_available_name` then hands back the requested key even when it is taken. Two uploads of the same filename therefore end up sharing a single object, and deleting either one destroys the other's file. That is how images have been losing their originals in Watch.

Note that a plain class attribute would not work here: `BaseStorage.__init__` applies `get_default_settings()` over the instance, so the default from `AWS_S3_FILE_OVERWRITE` would win.

Options coming from the storage URL query string arrive as strings, and a non-empty string is truthy, so `?file_overwrite=false` would have switched overwriting on rather than off. Parse the ones that spell out a boolean, leaving numeric values alone so that options taking a number stay intact.

## Related issue
[Sentry issue](https://sentry.kausal.tech/organizations/kausal/issues/18055/events/e7d035fb1b9e4a38886e6ae9f6a17f24/)

## Requirements, dependencies and related PRs
[kausal-watch PR](https://github.com/kausaltech/kausal-watch/pull/647)

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Manually tested locally in all affected projects** (functionality verified)